### PR TITLE
Update OLing to v3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 		    <groupId>net.oijon</groupId>
 		    <artifactId>oling</artifactId>
-		    <version>3.1.1</version>
+		    <version>3.1.2</version>
 		</dependency>
 		<dependency>
 		    <groupId>net.oijon</groupId>

--- a/src/main/java/net/oijon/susquehanna/SystemInfo.java
+++ b/src/main/java/net/oijon/susquehanna/SystemInfo.java
@@ -65,7 +65,7 @@ public final class SystemInfo {
      */
     public static String buildName() {
     	if (isSnapshot()) {
-    		return "26w33a";
+    		return "26w33b";
     	} else {
     		return susquehannaVerName() + ", " + susquehannaVerNum();
     	}

--- a/src/main/java/net/oijon/susquehanna/gui/scenes/file/AddLangPage.java
+++ b/src/main/java/net/oijon/susquehanna/gui/scenes/file/AddLangPage.java
@@ -49,7 +49,7 @@ public class AddLangPage extends Book {
 				
 				sl.getLanguage().getProperties().setProperty(LanguageProperty.NAME, languageName.getText());
 				sl.getLanguage().getProperties().setProperty(LanguageProperty.AUTONYM, languageAutonym.getText());
-				// FIXME: IDs need to not be null
+				sl.getLanguage().getProperties().generateID();
 				
 				sl.write();
 				


### PR DESCRIPTION
This updates OLing to v3.1.2, now allowing once more for ID generation on the creation of a new language.